### PR TITLE
Fix typo on dropdown label and Add support for The SEO Framework plugin

### DIFF
--- a/includes/class-seo-data-transporter-admin.php
+++ b/includes/class-seo-data-transporter-admin.php
@@ -109,7 +109,7 @@ class SEO_Data_Transporter_Admin {
 		}
 		echo '</optgroup>';
 
-		printf( '<optgroup label="%s">', __('Themes', 'seo-data-transporter') );
+		printf( '<optgroup label="%s">', __('Plugins', 'seo-data-transporter') );
 		foreach ( $plugins as $platform => $data ) {
 			printf( '<option value="%s">%s</option>', esc_attr( $platform ), esc_html( $platform ) );
 		}

--- a/seo-data-transporter.php
+++ b/seo-data-transporter.php
@@ -169,6 +169,15 @@ final class SEO_Data_Transporter {
 				'noindex'          => '_su_meta_robots_noindex',
 				'nofollow'         => '_su_meta_robots_nofollow',
 			),
+			'The SEO Framework' => array(
+				'Custom Doctitle'  => '_genesis_title',
+				'META Description' => '_genesis_description',
+				'noindex'          => '_genesis_noindex',
+				'nofollow'         => '_genesis_nofollow',
+				'noarchive'        => '_genesis_noarchive',
+				'Canonical URI'    => '_genesis_canonical_uri',
+				'Redirect URI'     => 'redirect',
+			),
 			'Yoast SEO' => array(
 				'Custom Doctitle'  => '_yoast_wpseo_title',
 				'META Description' => '_yoast_wpseo_metadesc',


### PR DESCRIPTION
- The `</optgroup>` element was showing **Themes** instead of **Plugins** for the Plugins options. So, I've fixed the wrong label to **Plugins**.
- Add support for [The SEO Framework](https://gl.wordpress.org/plugins/autodescription/) plugin.