### PR TITLE
Fixes issues with Greg's High Performance SEO.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,12 @@
 *.jpg binary
 *.gif binary
 *.ico binary
+
+# Export ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.svnignore export-ignore
+Gruntfile.js export-ignore
+package.json export-ignore
+README.md export-ignore
+screenshot-* export-ignore

--- a/includes/class-seo-data-transporter-admin.php
+++ b/includes/class-seo-data-transporter-admin.php
@@ -122,6 +122,7 @@ class SEO_Data_Transporter_Admin {
 	 * Process the form.
 	 *
 	 * @since 1.0.0
+	 * @since 1.1.1 Now unslashes the request arguments.
 	 */
 	public function process_form() {
 
@@ -142,6 +143,8 @@ class SEO_Data_Transporter_Admin {
 			add_action( 'admin_notices', array( $this, 'notice_error_select' ) );
 			return false;
 		}
+
+		$args = wp_unslash( $args );
 
 		// Utility object
 		require_once( SEO_Data_Transporter()->plugin_dir_path . 'includes/class-seo-data-transporter-utility.php' );

--- a/includes/class-seo-data-transporter-utility.php
+++ b/includes/class-seo-data-transporter-utility.php
@@ -4,7 +4,7 @@
  *
  * @since 1.0.0
  */
- class SEO_Data_Transporter_Utility {
+class SEO_Data_Transporter_Utility {
 
 	/**
 	 * Supported platforms.
@@ -35,15 +35,15 @@
 
 		$output = new stdClass;
 
+		$output->update   = 0;
+		$output->ignore   = 0;
+		$output->elements = array();
+
 		// Neither platform should be empty.
 		if ( empty( $this->platforms[ $old_platform ] ) || empty( $this->platforms[ $new_platform ] ) ) {
 			$output->WP_Error = 1;
 			return $output;
 		}
-
-		$output->update   = 0;
-		$output->ignore   = 0;
-		$output->elements = array();
 
 		foreach ( (array) $this->platforms[ $old_platform ] as $label => $meta_key ) {
 
@@ -92,14 +92,14 @@
 
 		$output = new stdClass;
 
+		$output->updated = 0;
+		$output->deleted = 0;
+		$output->ignored = 0;
+
 		if ( empty( $this->platforms[ $old_platform ] ) || empty( $this->platforms[ $new_platform ] ) ) {
 			$output->WP_Error = 1;
 			return $output;
 		}
-
-		$output->updated = 0;
-		$output->deleted = 0;
-		$output->ignored = 0;
 
 		foreach ( (array) $this->platforms[ $old_platform ] as $label => $meta_key ) {
 
@@ -146,10 +146,8 @@
 		$output = new stdClass;
 
 		if ( ! $old_key || ! $new_key ) {
-
 			$output->WP_Error = 1;
 			return $output;
-
 		}
 
 		// 	See which records we need to ignore, if any
@@ -185,4 +183,4 @@
 
 	}
 
- }
+}

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
 Plugin Name: SEO Data Transporter
 Plugin URI: https://wordpress.org/plugins/seo-data-transporter/
 Description: SEO Data Transporter helps you transfer post/page specific SEO data, like custom doctitles, custom META descriptions and keywords, etc., from one platform (theme or plugin) to another.
-Version: 1.1.0
+Version: 1.1.1
 Author: StudioPress
 Author URI: https://www.studiopress.com/
 Text Domain: seo-data-transporter

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: seo, genesis, genesiswp, thesis, thesiswp, headway, headwaywp, builder, frugal, hybrid, woothemes, all in one seo, headspace, platinum seo
 Requires at least: 4.7.3
 Tested up to: 5.0.3
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 
 This plugin allows you to transfer your inputs SEO data from one theme/plugin to another.
 
@@ -60,6 +60,10 @@ It's relatively stable. This plugin has been in the repository since August, 201
 1. The SEO Data Transporter UI, including the dropdown with all the supported platforms
 
 == Changelog ==
+
+= 1.1.1 =
+* Fix Greg's High Performance SEO selection
+* Fix PHP notices when an unknown plugin or theme is selected
 
 = 1.1.0 =
 * Add support for Praison SEO

--- a/seo-data-transporter.php
+++ b/seo-data-transporter.php
@@ -9,7 +9,7 @@ final class SEO_Data_Transporter {
 	/**
 	 * Plugin version
 	 */
-	public $plugin_version = '1.1.0';
+	public $plugin_version = '1.1.1';
 
 	/**
 	 * The plugin textdomain, for translations.


### PR DESCRIPTION
Hi there!

This pull request addresses these issues:
1. A slashing issue with Greg's High Performance SEO, where the `$_REQUEST` value adds a slash to the apostrophe, causing a failure when trying to match the known plugin list.
2. When 1. fails, no more PHP notices will occur in `notice_success_analyze()` because of missing properties. The properties are now set before returning the 
3. Updated the .gitattributes file, so users downloading the ZIP via GitHub won't get the development stuff, saving some bytes.
4. Updated the plugin to version 1.1.1.

As a note of caution on 3, the screenshot should be moved to `https://plugins.svn.wordpress.org/seo-data-transporter/assets/`