### PR TITLE
Bump the minimum PHP version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,11 @@ orbs:
 jobs:
   lint:
     docker:
-      - image: php:8.2.12-apache-bullseye
+      - image: wordpress:php8.2-apache
     steps:
       - checkout
       - run: php -i
+      - php/install-composer
       - php/install-packages
       - run: phpcs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 jobs:
   lint:
     docker:
-      - image: wordpress:php8.2-fpm
+      - image: wordpress:php8.2-fpm-alpine
     steps:
       - checkout
       - run: php -i

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,8 @@ jobs:
       - image: wordpress:php8.2-fpm-alpine
     steps:
       - checkout
-      - php/install-composer
-      - php/install-packages
       - run: php -i
+      - php/install-packages
       - run: phpcs
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  wp-svn: studiopress/wp-svn@0.1
   php: circleci/php@1.1
+  wp-svn: studiopress/wp-svn@0.1
 
 jobs:
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ workflows:
   test-deploy:
     jobs:
       - php/test:
-          test-command: phpcs
+          test-command: php -i && phpcs
       - approval-for-deploy-tested-up-to-bump:
           requires:
             - php/test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,9 @@ orbs:
 jobs:
   lint:
     docker:
-      - image: cimg/base:2021.04
+      - image: php:8.2.7-apache-bullseye
     steps:
       - checkout
-      - php/install-php:
-          version: '8.2'
       - run: php -i
       - php/install-composer
       - php/install-packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,11 @@ orbs:
 jobs:
   lint:
     docker:
-      - image: wordpress:php8.2-fpm-alpine
+      - image: cimg/base:latest
     steps:
       - checkout
       - run: php -i
+      - php/install-composer
       - php/install-packages
       - run: phpcs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,19 @@ jobs:
       - image: wordpress:php8.2-fpm-alpine
     steps:
       - checkout
-      - run: php -i
-      - php/install-composer
+      - run:
+          name: Install Composer
+          command: |
+            mkdir -p ~/project/bin
+            cd ~/project/bin
+            echo 'export PATH=$HOME/project/bin:$PATH' >> $BASH_ENV
+            source $BASH_ENV
+            php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+            EXPECTED_SIGNATURE=$(curl -s https://composer.github.io/installer.sig)
+            ACTUAL_SIGNATURE=$(php -r "echo hash_file('sha384', 'composer-setup.php');")
+            [[ "$EXPECTED_SIGNATURE" == "$ACTUAL_SIGNATURE" ]] && php composer-setup.php --install-dir=/root/project/bin --filename=composer || exit 1
+            rm composer-setup.php
+            composer config -g github-protocols https && composer config -g repo.packagist composer https://packagist.org
       - php/install-packages
       - run: phpcs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
             rm composer-setup.php
             composer config -g github-protocols https && composer config -g repo.packagist composer https://packagist.org
       - php/install-packages
-      - run: phpcs
+      - run: composer phpcs
 
 workflows:
   test-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 jobs:
   lint:
     docker:
-      - image: php:8.2.7-apache-bullseye
+      - image: php:8.2.12-apache-bullseye
     steps:
       - checkout
       - run: php -i

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  php: circleci/php@1.0
+  php: circleci/php@1.1
   wp-svn: studiopress/wp-svn@0.1
 
 workflows:
@@ -10,7 +10,7 @@ workflows:
       - php/test:
           test-command: phpcs
       - approval-for-deploy-tested-up-to-bump:
-          requires: 
+          requires:
             - php/test
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,16 @@ version: 2.1
 
 orbs:
   wp-svn: studiopress/wp-svn@0.1
+  php: circleci/php@1.1
 
 jobs:
   lint:
     docker:
-      - image: cimg/php:8.2
+      - image: cimg/php:8.2.12
     steps:
       - checkout
+      - php/install-composer
+      - php/install-packages
       - run: php -i
       - run: phpcs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,24 @@
 version: 2.1
 
 orbs:
-  php: circleci/php@1.1
   wp-svn: studiopress/wp-svn@0.1
+
+jobs:
+  lint:
+    docker:
+      - image: cimg/php:8.2
+    steps:
+      - checkout
+      - run: php -i
+      - run: phpcs
 
 workflows:
   test-deploy:
     jobs:
-      - php/test:
-          version: '8.2'
-          setup:
-            - run: php -i
-          test-command: phpcs
+      - lint
       - approval-for-deploy-tested-up-to-bump:
           requires:
-            - php/test
+            - lint
           type: approval
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
     steps:
       - checkout
       - run: php -i
-      - php/install-composer
       - php/install-packages
       - run: phpcs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ workflows:
   test-deploy:
     jobs:
       - php/test:
+          version: '8.2'
           setup:
             - run: php -i
           test-command: phpcs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       - image: cimg/base:2021.04
     steps:
       - checkout
+      - php/install-php
       - run: php -i
       - php/install-composer
       - php/install-packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 jobs:
   lint:
     docker:
-      - image: cimg/base:latest
+      - image: cimg/base:2021.04
     steps:
       - checkout
       - run: php -i

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 jobs:
   lint:
     docker:
-      - image: cimg/php:8.2.12
+      - image: wordpress:php8.2-fpm-alpine
     steps:
       - checkout
       - php/install-composer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ jobs:
       - image: cimg/base:2021.04
     steps:
       - checkout
-      - php/install-php
+      - php/install-php:
+          version: '8.2'
       - run: php -i
       - php/install-composer
       - php/install-packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ workflows:
   test-deploy:
     jobs:
       - php/test:
-          test-command: php -i && phpcs
+          test-command: curl --version && phpcs
       - approval-for-deploy-tested-up-to-bump:
           requires:
             - php/test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,9 @@ workflows:
   test-deploy:
     jobs:
       - php/test:
-          test-command: curl --version && phpcs
+          setup:
+            - run: php -i
+          test-command: phpcs
       - approval-for-deploy-tested-up-to-bump:
           requires:
             - php/test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 jobs:
   lint:
     docker:
-      - image: wordpress:php8.2-apache
+      - image: wordpress:php8.2-fpm
     steps:
       - checkout
       - run: php -i

--- a/composer.json
+++ b/composer.json
@@ -5,16 +5,16 @@
 	"homepage": "https://github.com/studiopress/seo-data-transporter",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": "^5.3 || ^7 || ^8",
+		"php": "^8.1",
 		"composer/installers": "^1"
 	},
 	"require-dev": {
-		"php": "^5.6 || ^7 || ^8",
-		"dealerdirect/phpcodesniffer-composer-installer": "*",
+		"php": "^8.1",
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
 		"squizlabs/php_codesniffer": "^3.7.2",
-		"phpcompatibility/phpcompatibility-wp": "*",
+		"phpcompatibility/phpcompatibility-wp": "^2.1.4",
 		"wp-coding-standards/wpcs": "^3.0.1",
-		"wp-cli/i18n-command": "^2.1"
+		"wp-cli/i18n-command": "^2.4.4"
 	},
 	"config": {
 		"sort-order": true,

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
 	"require-dev": {
 		"php": "^5.6 || ^7 || ^8",
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
-		"squizlabs/php_codesniffer": "^3.3.1",
+		"squizlabs/php_codesniffer": "^3.7.2",
 		"phpcompatibility/phpcompatibility-wp": "*",
-		"wp-coding-standards/wpcs": "^1",
+		"wp-coding-standards/wpcs": "^3.0.1",
 		"wp-cli/i18n-command": "^2.1"
 	},
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f7066e71b7d4c3dc1acf462c691e5e4c",
+    "content-hash": "42bd95909d903753e659a391aced0603",
     "packages": [
         {
             "name": "composer/installers",
@@ -1305,10 +1305,10 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.3 || ^7 || ^8"
+        "php": "^8.1"
     },
     "platform-dev": {
-        "php": "^5.6 || ^7 || ^8"
+        "php": "^8.1"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "63a5bee5bf3ba272c234fb8f33882ef0",
+    "content-hash": "f7066e71b7d4c3dc1acf462c691e5e4c",
     "packages": [
         {
             "name": "composer/installers",
@@ -161,35 +161,38 @@
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.2",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3",
+                "php": ">=5.4",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
                 "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0"
+                "phpcompatibility/php-compatibility": "^9.0",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
             },
             "autoload": {
                 "psr-4": {
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -205,7 +208,7 @@
                 },
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
@@ -229,10 +232,10 @@
                 "tests"
             ],
             "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2022-02-04T12:51:07+00:00"
+            "time": "2023-01-05T11:28:13+00:00"
         },
         {
             "name": "eftec/bladeone",
@@ -294,16 +297,16 @@
         },
         {
             "name": "gettext/gettext",
-            "version": "v4.8.6",
+            "version": "v4.8.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-gettext/Gettext.git",
-                "reference": "bbeb8f4d3077663739aecb4551b22e720c0e9efe"
+                "reference": "b632aaf5e4579d0b2ae8bc61785e238bff4c5156"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-gettext/Gettext/zipball/bbeb8f4d3077663739aecb4551b22e720c0e9efe",
-                "reference": "bbeb8f4d3077663739aecb4551b22e720c0e9efe",
+                "url": "https://api.github.com/repos/php-gettext/Gettext/zipball/b632aaf5e4579d0b2ae8bc61785e238bff4c5156",
+                "reference": "b632aaf5e4579d0b2ae8bc61785e238bff4c5156",
                 "shasum": ""
             },
             "require": {
@@ -355,7 +358,7 @@
             "support": {
                 "email": "oom@oscarotero.com",
                 "issues": "https://github.com/oscarotero/Gettext/issues",
-                "source": "https://github.com/php-gettext/Gettext/tree/v4.8.6"
+                "source": "https://github.com/php-gettext/Gettext/tree/v4.8.11"
             },
             "funding": [
                 {
@@ -371,20 +374,20 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-10-19T10:44:53+00:00"
+            "time": "2023-08-14T15:15:05+00:00"
         },
         {
             "name": "gettext/languages",
-            "version": "2.9.0",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-gettext/Languages.git",
-                "reference": "ed56dd2c7f4024cc953ed180d25f02f2640e3ffa"
+                "reference": "4d61d67fe83a2ad85959fe6133d6d9ba7dddd1ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/ed56dd2c7f4024cc953ed180d25f02f2640e3ffa",
-                "reference": "ed56dd2c7f4024cc953ed180d25f02f2640e3ffa",
+                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/4d61d67fe83a2ad85959fe6133d6d9ba7dddd1ab",
+                "reference": "4d61d67fe83a2ad85959fe6133d6d9ba7dddd1ab",
                 "shasum": ""
             },
             "require": {
@@ -433,7 +436,7 @@
             ],
             "support": {
                 "issues": "https://github.com/php-gettext/Languages/issues",
-                "source": "https://github.com/php-gettext/Languages/tree/2.9.0"
+                "source": "https://github.com/php-gettext/Languages/tree/2.10.0"
             },
             "funding": [
                 {
@@ -445,20 +448,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-11-11T17:30:39+00:00"
+            "time": "2022-10-18T15:00:10+00:00"
         },
         {
             "name": "mck89/peast",
-            "version": "v1.14.0",
+            "version": "v1.15.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "70a728d598017e237118652b2fa30fbaa9d4ef6d"
+                "reference": "1df4dc28a6b5bb7ab117ab073c1712256e954e18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/70a728d598017e237118652b2fa30fbaa9d4ef6d",
-                "reference": "70a728d598017e237118652b2fa30fbaa9d4ef6d",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/1df4dc28a6b5bb7ab117ab073c1712256e954e18",
+                "reference": "1df4dc28a6b5bb7ab117ab073c1712256e954e18",
                 "shasum": ""
             },
             "require": {
@@ -471,13 +474,12 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.14.0-dev"
+                    "dev-master": "1.15.4-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Peast\\": "lib/Peast/",
-                    "Peast\\test\\": "test/Peast/"
+                    "Peast\\": "lib/Peast/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -493,22 +495,22 @@
             "description": "Peast is PHP library that generates AST for JavaScript code",
             "support": {
                 "issues": "https://github.com/mck89/peast/issues",
-                "source": "https://github.com/mck89/peast/tree/v1.14.0"
+                "source": "https://github.com/mck89/peast/tree/v1.15.4"
             },
-            "time": "2022-05-01T15:09:54+00:00"
+            "time": "2023-08-12T08:29:29+00:00"
         },
         {
             "name": "mustache/mustache",
-            "version": "v2.14.1",
+            "version": "v2.14.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/mustache.php.git",
-                "reference": "579ffa5c96e1d292c060b3dd62811ff01ad8c24e"
+                "reference": "e62b7c3849d22ec55f3ec425507bf7968193a6cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/579ffa5c96e1d292c060b3dd62811ff01ad8c24e",
-                "reference": "579ffa5c96e1d292c060b3dd62811ff01ad8c24e",
+                "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/e62b7c3849d22ec55f3ec425507bf7968193a6cb",
+                "reference": "e62b7c3849d22ec55f3ec425507bf7968193a6cb",
                 "shasum": ""
             },
             "require": {
@@ -543,9 +545,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/mustache.php/issues",
-                "source": "https://github.com/bobthecow/mustache.php/tree/v2.14.1"
+                "source": "https://github.com/bobthecow/mustache.php/tree/v2.14.2"
             },
-            "time": "2022-01-21T06:08:36+00:00"
+            "time": "2022-08-23T13:07:01+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -611,16 +613,16 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
                 "shasum": ""
             },
             "require": {
@@ -657,26 +659,27 @@
                 "paragonie",
                 "phpcs",
                 "polyfill",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
             },
-            "time": "2021-02-15T10:24:51+00:00"
+            "time": "2022-10-25T01:46:02+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.3",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308"
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/d55de55f88697b9cdb94bccf04f14eb3b11cf308",
-                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
                 "shasum": ""
             },
             "require": {
@@ -711,86 +714,163 @@
                 "compatibility",
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2021-12-30T16:37:40+00:00"
+            "time": "2022-10-24T09:00:36+00:00"
         },
         {
-            "name": "rmccue/requests",
-            "version": "v1.8.1",
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress/Requests.git",
-                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5"
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/Requests/zipball/82e6936366eac3af4d836c18b9d8c31028fe4cd5",
-                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2"
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.1"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-                "php-parallel-lint/php-console-highlighter": "^0.5.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5",
-                "requests/test-server": "dev-master",
-                "squizlabs/php_codesniffer": "^3.5",
-                "wp-coding-standards/wpcs": "^2.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
             },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Requests": "library/"
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "ISC"
+                "LGPL-3.0-or-later"
             ],
             "authors": [
                 {
-                    "name": "Ryan McCue",
-                    "homepage": "http://ryanmccue.info"
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
                 }
             ],
-            "description": "A HTTP library written in PHP, for human beings.",
-            "homepage": "http://github.com/WordPress/Requests",
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
             "keywords": [
-                "curl",
-                "fsockopen",
-                "http",
-                "idna",
-                "ipv6",
-                "iri",
-                "sockets"
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/WordPress/Requests/issues",
-                "source": "https://github.com/WordPress/Requests/tree/v1.8.1"
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
             },
-            "time": "2021-06-04T09:56:25+00:00"
+            "time": "2023-09-20T22:06:18+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.6.2",
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "time": "2023-07-16T21:39:41+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -826,100 +906,35 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-12-12T21:44:58+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v2.5.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "2.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.8",
+            "version": "v6.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "9b630f3427f3ebe7cd346c277a1408b00249dad9"
+                "reference": "a1b31d88c0e998168ca7792f222cbecee47428c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/9b630f3427f3ebe7cd346c277a1408b00249dad9",
-                "reference": "9b630f3427f3ebe7cd346c277a1408b00249dad9",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/a1b31d88c0e998168ca7792f222cbecee47428c4",
+                "reference": "a1b31d88c0e998168ca7792f222cbecee47428c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.0"
             },
             "type": "library",
             "autoload": {
@@ -947,7 +962,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.8"
+                "source": "https://github.com/symfony/finder/tree/v6.3.5"
             },
             "funding": [
                 {
@@ -963,103 +978,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-15T08:07:45+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.25.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "4407588e0d3f1f52efb65fbe92babe41f37fe50c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/4407588e0d3f1f52efb65fbe92babe41f37fe50c",
-                "reference": "4407588e0d3f1f52efb65fbe92babe41f37fe50c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.25.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-03-04T08:16:47+00:00"
+            "time": "2023-09-26T12:56:25+00:00"
         },
         {
             "name": "wp-cli/i18n-command",
-            "version": "v2.3.0",
+            "version": "v2.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/i18n-command.git",
-                "reference": "bcb1a8159679cafdf1da884dbe5830122bae2c4d"
+                "reference": "7d82e675f271359b1af614e6325d8eeaeb7d7474"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/bcb1a8159679cafdf1da884dbe5830122bae2c4d",
-                "reference": "bcb1a8159679cafdf1da884dbe5830122bae2c4d",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/7d82e675f271359b1af614e6325d8eeaeb7d7474",
+                "reference": "7d82e675f271359b1af614e6325d8eeaeb7d7474",
                 "shasum": ""
             },
             "require": {
@@ -1070,9 +1002,10 @@
             },
             "require-dev": {
                 "wp-cli/scaffold-command": "^1.2 || ^2",
-                "wp-cli/wp-cli-tests": "^3.1"
+                "wp-cli/wp-cli-tests": "^4"
             },
             "suggest": {
+                "ext-json": "Used for reading and generating JSON translation files",
                 "ext-mbstring": "Used for calculating include/exclude matches in code extraction"
             },
             "type": "wp-cli-package",
@@ -1084,7 +1017,9 @@
                 "commands": [
                     "i18n",
                     "i18n make-pot",
-                    "i18n make-json"
+                    "i18n make-json",
+                    "i18n make-mo",
+                    "i18n update-po"
                 ]
             },
             "autoload": {
@@ -1109,9 +1044,9 @@
             "homepage": "https://github.com/wp-cli/i18n-command",
             "support": {
                 "issues": "https://github.com/wp-cli/i18n-command/issues",
-                "source": "https://github.com/wp-cli/i18n-command/tree/v2.3.0"
+                "source": "https://github.com/wp-cli/i18n-command/tree/v2.4.4"
             },
-            "time": "2022-04-06T15:32:48+00:00"
+            "time": "2023-08-30T18:00:10+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -1166,22 +1101,31 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.13",
+            "version": "v0.11.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "a2866855ac1abc53005c102e901553ad5772dc04"
+                "reference": "b3457a8d60cd0b1c48cab76ad95df136d266f0b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/a2866855ac1abc53005c102e901553ad5772dc04",
-                "reference": "a2866855ac1abc53005c102e901553ad5772dc04",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/b3457a8d60cd0b1c48cab76ad95df136d266f0b6",
+                "reference": "b3457a8d60cd0b1c48cab76ad95df136d266f0b6",
                 "shasum": ""
             },
             "require": {
                 "php": ">= 5.3.0"
             },
+            "require-dev": {
+                "roave/security-advisories": "dev-latest",
+                "wp-cli/wp-cli-tests": "^4"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.11.x-dev"
+                }
+            },
             "autoload": {
                 "files": [
                     "lib/cli/cli.php"
@@ -1214,29 +1158,28 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-cli/php-cli-tools/issues",
-                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.13"
+                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.21"
             },
-            "time": "2021-07-01T15:08:16+00:00"
+            "time": "2023-09-29T15:28:10+00:00"
         },
         {
             "name": "wp-cli/wp-cli",
-            "version": "v2.6.0",
+            "version": "v2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "dee13c2baf6bf972484a63f8b8dab48f7220f095"
+                "reference": "8a3befba2d947fbf5cc6d1941edf2dd99da4d4b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/dee13c2baf6bf972484a63f8b8dab48f7220f095",
-                "reference": "dee13c2baf6bf972484a63f8b8dab48f7220f095",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/8a3befba2d947fbf5cc6d1941edf2dd99da4d4b7",
+                "reference": "8a3befba2d947fbf5cc6d1941edf2dd99da4d4b7",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "mustache/mustache": "^2.14.1",
                 "php": "^5.6 || ^7.0 || ^8.0",
-                "rmccue/requests": "^1.8",
                 "symfony/finder": ">2.7",
                 "wp-cli/mustangostang-spyc": "^0.6.3",
                 "wp-cli/php-cli-tools": "~0.11.2"
@@ -1247,7 +1190,7 @@
                 "wp-cli/entity-command": "^1.2 || ^2",
                 "wp-cli/extension-command": "^1.1 || ^2",
                 "wp-cli/package-command": "^1 || ^2",
-                "wp-cli/wp-cli-tests": "^3.1.3"
+                "wp-cli/wp-cli-tests": "^4.0.1"
             },
             "suggest": {
                 "ext-readline": "Include for a better --prompt implementation",
@@ -1260,7 +1203,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6.x-dev"
+                    "dev-main": "2.9.x-dev"
                 }
             },
             "autoload": {
@@ -1287,31 +1230,42 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2022-01-25T16:31:27+00:00"
+            "time": "2023-10-25T09:06:37+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "1.2.1",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c"
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
-                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=5.4",
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "phpcompatibility/php-compatibility": "^9.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1321,21 +1275,28 @@
             "authors": [
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
-                "issues": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues",
-                "source": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards",
-                "wiki": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki"
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2018-12-18T09:43:51+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/thewpcc/contribute/wp-php-63406",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-09-14T07:06:09+00:00"
         }
     ],
     "aliases": [],
@@ -1349,5 +1310,5 @@
     "platform-dev": {
         "php": "^5.6 || ^7 || ^8"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/includes/class-seo-data-transporter-admin.php
+++ b/includes/class-seo-data-transporter-admin.php
@@ -47,7 +47,6 @@ class SEO_Data_Transporter_Admin {
 
 		$this->themes  = $themes;
 		$this->plugins = $plugins;
-
 	}
 
 	/**
@@ -68,7 +67,6 @@ class SEO_Data_Transporter_Admin {
 		);
 
 		add_action( 'admin_menu', array( $this, 'create' ) );
-
 	}
 
 	/**
@@ -92,7 +90,6 @@ class SEO_Data_Transporter_Admin {
 
 		// If we need to load scripts for this page.
 		add_action( "load-{$this->pagehook}", array( $this, 'process_form' ) );
-
 	}
 
 	/**
@@ -103,7 +100,6 @@ class SEO_Data_Transporter_Admin {
 	public function admin() {
 
 		require_once SEO_Data_Transporter()->plugin_dir_path . 'includes/views/admin.php';
-
 	}
 
 	/**
@@ -132,7 +128,6 @@ class SEO_Data_Transporter_Admin {
 		}
 		echo '</optgroup>';
 		echo '</select>';
-
 	}
 
 	/**
@@ -191,7 +186,6 @@ class SEO_Data_Transporter_Admin {
 		add_action( 'admin_notices', array( $this, 'notice_success_convert' ) );
 
 		return true;
-
 	}
 
 	/**
@@ -203,7 +197,6 @@ class SEO_Data_Transporter_Admin {
 
 		$message = __( 'Something went wrong. Please make your selection and try again.', 'seo-data-transporter' );
 		printf( '<div class="notice notice-error"><p>%s</p></div>', esc_html( $message ) );
-
 	}
 
 	/**
@@ -215,7 +208,6 @@ class SEO_Data_Transporter_Admin {
 
 		$message = __( 'You must choose two different platforms before submitting.', 'seo-data-transporter' );
 		printf( '<div class="notice notice-error"><p>%s</p></div>', esc_html( $message ) );
-
 	}
 
 	/**
@@ -240,7 +232,6 @@ class SEO_Data_Transporter_Admin {
 			echo '</p>';
 
 		echo '</div>';
-
 	}
 
 	/**
@@ -254,7 +245,5 @@ class SEO_Data_Transporter_Admin {
 			printf( '<p><b>%d</b> %s</p>', isset( $this->conversion_result->updated ) ? esc_attr( $this->conversion_result->updated ) : 0, esc_html( __( 'records were updated', 'seo-data-transporter' ) ) );
 			printf( '<p><b>%d</b> %s</p>', isset( $this->conversion_result->ignored ) ? esc_attr( $this->conversion_result->ignored ) : 0, esc_html( __( 'records were ignored', 'seo-data-transporter' ) ) );
 		echo '</div>';
-
 	}
-
 }

--- a/includes/class-seo-data-transporter-cli.php
+++ b/includes/class-seo-data-transporter-cli.php
@@ -102,7 +102,5 @@ class SEO_Data_Transporter_CLI extends WP_CLI_Command {
 
 		// Translators: Number is the number of records converted.
 		WP_CLI::success( sprintf( __( '%d records were successfully converted.', 'seo-data-transporter' ), $result->updated ) );
-
 	}
-
 }

--- a/includes/class-seo-data-transporter-utility.php
+++ b/includes/class-seo-data-transporter-utility.php
@@ -29,7 +29,6 @@ class SEO_Data_Transporter_Utility {
 	public function __construct( $platforms ) {
 
 		$this->platforms = $platforms;
-
 	}
 
 	/**
@@ -50,7 +49,7 @@ class SEO_Data_Transporter_Utility {
 
 		// Neither platform should be empty.
 		if ( empty( $this->platforms[ $old_platform ] ) || empty( $this->platforms[ $new_platform ] ) ) {
-			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName
 			$output->WP_Error = 1;
 			return $output;
 		}
@@ -88,7 +87,6 @@ class SEO_Data_Transporter_Utility {
 		do_action( 'seodt_post_meta_analyze', $output, $old_platform, $new_platform );
 
 		return $output;
-
 	}
 
 	/**
@@ -107,7 +105,7 @@ class SEO_Data_Transporter_Utility {
 		$output = new stdClass();
 
 		if ( empty( $this->platforms[ $old_platform ] ) || empty( $this->platforms[ $new_platform ] ) ) {
-			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName
 			$output->WP_Error = 1;
 			return $output;
 		}
@@ -144,7 +142,6 @@ class SEO_Data_Transporter_Utility {
 		do_action( 'seodt_post_meta_convert', $output, $old_platform, $new_platform, $delete_old );
 
 		return $output;
-
 	}
 
 	/**
@@ -165,7 +162,7 @@ class SEO_Data_Transporter_Utility {
 		$output = new stdClass();
 
 		if ( ! $old_key || ! $new_key ) {
-			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName
 			$output->WP_Error = 1;
 			return $output;
 
@@ -199,7 +196,5 @@ class SEO_Data_Transporter_Utility {
 		do_action( 'seodt_meta_key_convert', $output, $old_key, $new_key, $delete_old );
 
 		return $output;
-
 	}
-
 }

--- a/includes/class-seo-data-transporter.php
+++ b/includes/class-seo-data-transporter.php
@@ -215,7 +215,6 @@ final class SEO_Data_Transporter {
 				'Redirect URI'     => '_yoast_wpseo_redirect',
 			),
 		);
-
 	}
 
 	/**
@@ -238,7 +237,6 @@ final class SEO_Data_Transporter {
 		 * @since 0.9.10
 		 */
 		do_action( 'seodt_init' );
-
 	}
 
 	/**
@@ -258,7 +256,6 @@ final class SEO_Data_Transporter {
 	public function includes() {
 
 		require_once $this->plugin_dir_path . 'includes/deprecated.php';
-
 	}
 
 	/**
@@ -282,7 +279,6 @@ final class SEO_Data_Transporter {
 			require_once $this->plugin_dir_path . 'includes/class-seo-data-transporter-cli.php';
 			WP_CLI::add_command( 'seodt', 'SEO_Data_Transporter_CLI' );
 		}
-
 	}
 
 	/**
@@ -311,5 +307,4 @@ final class SEO_Data_Transporter {
 	public function get_supported_platforms() {
 		return array_merge( $this->themes, $this->plugins );
 	}
-
 }

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -15,7 +15,6 @@
 function seodt_init() {
 
 	_deprecated_function( __FUNCTION__, '1.0.0', 'SEO_Data_Transporter::init()' );
-
 }
 
 /**
@@ -26,7 +25,6 @@ function seodt_init() {
 function seodt_activation_hook() {
 
 	_deprecated_function( __FUNCTION__, '1.0.0' );
-
 }
 
 /**
@@ -45,7 +43,6 @@ function seodt_meta_key_convert( $old_key, $new_key, $delete_old ) {
 	$utility = SEO_Data_Transporter_Utility( SEO_Data_Transporter()->get_supported_platforms() );
 
 	return $utility->meta_key_convert( $old_key, $new_key, $delete_old );
-
 }
 
 /**
@@ -64,7 +61,6 @@ function seodt_post_meta_convert( $old_platform, $new_platform, $delete_old ) {
 	$utility = SEO_Data_Transporter_Utility( SEO_Data_Transporter()->get_supported_platforms() );
 
 	return $utility->convert( $old_platform, $new_platform, $delete_old );
-
 }
 
 /**
@@ -82,7 +78,6 @@ function seodt_post_meta_analyze( $old_platform, $new_platform ) {
 	$utility = SEO_Data_Transporter_Utility( SEO_Data_Transporter()->get_supported_platforms() );
 
 	return $utility->analyze( $old_platform, $new_platform, $delete_old );
-
 }
 
 /**
@@ -93,7 +88,6 @@ function seodt_post_meta_analyze( $old_platform, $new_platform ) {
 function seodt_settings_init() {
 
 	_deprecated_function( __FUNCTION__, '1.0.0' );
-
 }
 
 /**
@@ -105,7 +99,6 @@ function seodt_settings_init() {
 function seodt_action() {
 
 	_deprecated_function( __FUNCTION__, '1.0.0' );
-
 }
 
 /**
@@ -116,5 +109,4 @@ function seodt_action() {
 function seodt_admin() {
 
 	_deprecated_function( __FUNCTION__, '1.0.0' );
-
 }

--- a/plugin.php
+++ b/plugin.php
@@ -10,6 +10,7 @@ Plugin Name: SEO Data Transporter
 Plugin URI: https://wordpress.org/plugins/seo-data-transporter/
 Description: SEO Data Transporter helps you transfer post/page specific SEO data, like custom doctitles, custom META descriptions and keywords, etc., from one platform (theme or plugin) to another.
 Version: 1.1.1
+Requires PHP: 8.1
 Author: StudioPress
 Author URI: https://www.studiopress.com/
 Text Domain: seo-data-transporter

--- a/seo-data-transporter.php
+++ b/seo-data-transporter.php
@@ -25,7 +25,6 @@ function seo_data_transporter() {
 	}
 
 	return $object;
-
 }
 
 /**


### PR DESCRIPTION
Bumps the minimum PHP version to `8.1`, so users will be more likely to have a secure version of `curl`.

A [dev dependency](https://github.com/studiopress/seo-data-transporter/blob/d418cce25d26115d0055a4c67ba8dc5d370abae8/composer.lock#L1236) runs `ext-curl`, which has a vulnerability. 

Fixes [GF-3880](https://wpengine.atlassian.net/browse/GF-3880)

### How to test
Not needed