### PR TITLE
ci: reinstate 'tested up to' deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   php: circleci/php@1.1
-  # wp-svn: studiopress/wp-svn@0.1
+  wp-svn: studiopress/wp-svn@0.1
 
 jobs:
   lint:
@@ -30,16 +30,16 @@ workflows:
   test-deploy:
     jobs:
       - lint
-      # - approval-for-deploy-tested-up-to-bump:
-      #     requires:
-      #       - lint
-      #     type: approval
-      #     filters:
-      #       tags:
-      #         ignore: /.*/
-      #       branches:
-      #         only: /^bump-tested-up-to.*/
-      # - wp-svn/deploy-tested-up-to-bump:
-      #     context: genesis-svn
-      #     requires:
-      #       - approval-for-deploy-tested-up-to-bump
+      - approval-for-deploy-tested-up-to-bump:
+          requires:
+            - lint
+          type: approval
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only: /^bump-tested-up-to.*/
+      - wp-svn/deploy-tested-up-to-bump:
+          context: genesis-svn
+          requires:
+            - approval-for-deploy-tested-up-to-bump


### PR DESCRIPTION
WP.org is no longer blocked, we can deploy 'tested up to' updates this way again.

