### PR TITLE
chore: bump 'tested up to' to 6.9

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -9,7 +9,7 @@
 Plugin Name: SEO Data Transporter
 Plugin URI: https://wordpress.org/plugins/seo-data-transporter/
 Description: SEO Data Transporter helps you transfer post/page specific SEO data, like custom doctitles, custom META descriptions and keywords, etc., from one platform (theme or plugin) to another.
-Version: 1.1.1
+Version: 1.1.2
 Requires PHP: 8.1
 Author: StudioPress
 Author URI: https://www.studiopress.com/

--- a/plugin.php
+++ b/plugin.php
@@ -9,7 +9,7 @@
 Plugin Name: SEO Data Transporter
 Plugin URI: https://wordpress.org/plugins/seo-data-transporter/
 Description: SEO Data Transporter helps you transfer post/page specific SEO data, like custom doctitles, custom META descriptions and keywords, etc., from one platform (theme or plugin) to another.
-Version: 1.1.2
+Version: 1.1.1
 Requires PHP: 8.1
 Author: StudioPress
 Author URI: https://www.studiopress.com/

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, studiopress, mazedulislamkhan, joostdevalk
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5553118
 Tags: seo, genesis, genesiswp, thesis, thesiswp, headway, headwaywp, builder, frugal, hybrid, woothemes, all in one seo, headspace, platinum seo
 Requires at least: 4.7.3
-Tested up to: 6.6
+Tested up to: 6.9
 Stable tag: 1.1.2
 
 This plugin allows you to transfer your inputs SEO data from one theme/plugin to another.


### PR DESCRIPTION
We have to also downgrade the version so that the svn orb updates the 'tested up to' string in the correct tag/[version] folder.
