### PR TITLE
chore: mark as tested with WP 7.0

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -9,7 +9,7 @@
 Plugin Name: SEO Data Transporter
 Plugin URI: https://wordpress.org/plugins/seo-data-transporter/
 Description: SEO Data Transporter helps you transfer post/page specific SEO data, like custom doctitles, custom META descriptions and keywords, etc., from one platform (theme or plugin) to another.
-Version: 1.1.1
+Version: 1.1.2
 Requires PHP: 8.1
 Author: StudioPress
 Author URI: https://www.studiopress.com/

--- a/plugin.php
+++ b/plugin.php
@@ -9,7 +9,7 @@
 Plugin Name: SEO Data Transporter
 Plugin URI: https://wordpress.org/plugins/seo-data-transporter/
 Description: SEO Data Transporter helps you transfer post/page specific SEO data, like custom doctitles, custom META descriptions and keywords, etc., from one platform (theme or plugin) to another.
-Version: 1.1.2
+Version: 1.1.1
 Requires PHP: 8.1
 Author: StudioPress
 Author URI: https://www.studiopress.com/

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: seo, genesis, genesiswp, thesis, thesiswp, headway, headwaywp, builder, frugal, hybrid, woothemes, all in one seo, headspace, platinum seo
 Requires at least: 4.7.3
 Tested up to: 7.0
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 
 This plugin allows you to transfer your inputs SEO data from one theme/plugin to another.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: nathanrice, studiopress, mazedulislamkhan, joostdevalk
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5553118
 Tags: seo, genesis, genesiswp, thesis, thesiswp, headway, headwaywp, builder, frugal, hybrid, woothemes, all in one seo, headspace, platinum seo
 Requires at least: 4.7.3
-Tested up to: 6.9
-Stable tag: 1.1.2
+Tested up to: 7.0
+Stable tag: 1.1.1
 
 This plugin allows you to transfer your inputs SEO data from one theme/plugin to another.
 


### PR DESCRIPTION
Already deployed readme update from this PR to https://wordpress.org/plugins/seo-data-transporter/.

Review only needed to merge to develop.

---

Commits includes a reverted temporary downgrade of stable tag/version so that CI pushes tags to the correct remote SVN branch to match the version deployed to WP.org.

https://wordpress.org/plugins/seo-data-transporter/ currently shows 1.1.1.

Version 1.1.2 here was not deployed to WP.org as it has WPE-specific update logic. That would need to be removed before it could be re-deployed in full.
